### PR TITLE
Use crystal-lang/json_mapping.cr

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -12,4 +12,7 @@ license: MIT
 dependencies:
   inflector:
     github: phoffer/inflector.cr
-    version: "~> 0.1.8"
+    version: ~> 0.1.8
+  json_mapping:
+    github: crystal-lang/json_mapping.cr
+    version: ~> 0.1.0

--- a/src/liquid/context.cr
+++ b/src/liquid/context.cr
@@ -1,4 +1,5 @@
 require "json"
+require "json_mapping"
 require "./any"
 
 module Liquid


### PR DESCRIPTION
`JSON.mapping` is deprecated in Crystal 0.35.0
Either add the mentioned dependency or migrate the implementation to use `Serializable` to avoid warnings.

These changes are backward compatible.

Note that starting on shards 0.11 the crystal property has semantic and will be used to restrict which versions of the shards can be used for a given crystal version.