### PR TITLE
Implement Liquid::Drop.

### DIFF
--- a/spec/blocks_spec.cr
+++ b/spec/blocks_spec.cr
@@ -190,51 +190,35 @@ describe Liquid do
     describe Filtered do
       it "should filter a string" do
         node = Filtered.new " \"whatever\" | abs"
-        v = RenderVisitor.new
-        node.accept v
-        v.output.should eq "whatever"
+        node_output(node).should eq "whatever"
       end
 
       it "should filter a int" do
         node = Filtered.new "-12 | abs"
-        v = RenderVisitor.new
-        node.accept v
-        v.output.should eq "12"
+        node_output(node).should eq "12"
       end
 
       it "should filter a float" do
         node = Filtered.new "-12.25 | abs"
-        v = RenderVisitor.new
-        node.accept v
-        v.output.should eq "12.25"
+        node_output(node).should eq "12.25"
       end
 
       it "should filter a var" do
         node = Filtered.new "var | abs"
-        ctx = Context.new
-        ctx.set "var", -12
-        v = RenderVisitor.new ctx
-        node.accept v
-        v.output.should eq "12"
+        ctx = Context{"var" => -12}
+        node_output(node, ctx).should eq "12"
       end
 
       it "should use multiple filters" do
         node = Filtered.new "var | append: \"Hello \" | append: \"World !\""
-        ctx = Context.new
-        ctx.set "var", ""
-        v = RenderVisitor.new ctx
-        node.accept v
-        v.output.should eq "Hello World !"
+        ctx = Context{"var" => ""}
+        node_output(node, ctx).should eq "Hello World !"
       end
 
       it "should filter with an argument" do
         node = Filtered.new "var | append: var2"
-        ctx = Context.new
-        ctx.set "var", "Hello"
-        ctx.set "var2", " World !"
-        v = RenderVisitor.new ctx
-        node.accept v
-        v.output.should eq "Hello World !"
+        ctx = Context{"var" => "Hello", "var2" => " World !"}
+        node_output(node, ctx).should eq "Hello World !"
       end
     end
 

--- a/spec/liquid_spec.cr
+++ b/spec/liquid_spec.cr
@@ -50,7 +50,7 @@ describe Liquid do
       expect_raises(KeyError) { ctx.get("obj.missing") }
     end
 
-    it "returns nil for missing key in strict mode with ?" do
+    pending "returns nil for missing key in strict mode with ?" do
       ctx = Context.new(strict: true)
       ctx.get("missing?").should be_nil
       ctx.get("obj.missing?").should be_nil

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,8 +3,9 @@ require "../src/liquid"
 
 include Liquid
 
-def node_output(node : Node, ctx : Context)
-  v = RenderVisitor.new ctx, IO::Memory.new
-  node.accept v
-  v.output
+def node_output(node : Node, ctx : Context = Context.new) : String
+  io = IO::Memory.new
+  v = RenderVisitor.new(ctx, io)
+  node.accept(v)
+  io.to_s
 end

--- a/spec/stack_machine_spec.cr
+++ b/spec/stack_machine_spec.cr
@@ -1,0 +1,193 @@
+require "./spec_helper"
+
+private class TextDrop < Drop
+  def array
+    Any{"text0", "text1"}
+  end
+
+  def text
+    "text from drop"
+  end
+
+  private def private_method
+    "bad"
+  end
+
+  private def protected_method
+    "bad"
+  end
+
+  def method_with_arg(arg)
+    "bad"
+  end
+end
+
+private class ProductDrop < Drop
+  def texts
+    TextDrop.new
+  end
+end
+
+private class SuperTextDrop < TextDrop
+  def super_text
+    "super_text"
+  end
+end
+
+private def compile(expr : String) : String
+  StackMachine.new(expr).tap(&.compile).to_s
+end
+
+private def evaluate(expr : String, vars : Hash(String, Any)) : Any
+  StackMachine.new(expr).evaluate(vars)
+end
+
+describe StackMachine do
+  it "parses an empty string" do
+    compile("").should eq("")
+  end
+
+  it "parses a blank string" do
+    compile("  ").should eq("")
+    compile(" \t ").should eq("")
+  end
+
+  it "parses string literals" do
+    compile("'foo'").should eq("PushLiteral foo;")
+    compile("\"foo\"").should eq("PushLiteral foo;")
+    compile("'fo\\'o'").should eq("PushLiteral fo'o;")
+    compile("\"fo\\\"o\"").should eq("PushLiteral fo\"o;")
+  end
+
+  it "raises on unclosed string literals" do
+    ["'foo", "'foo\\'", "\"foo", "\"foo\\\""].each do |test_string|
+      expect_raises(Exception, "Unterminated string literal.") do
+        compile(test_string)
+      end
+    end
+  end
+
+  it "recognize \n" do
+    compile("'\\n'").should eq("PushLiteral \n;")
+  end
+
+  it "recognize \t" do
+    compile("'\\t'").should eq("PushLiteral \t;")
+  end
+
+  it "parses 'foo'" do
+    compile("foo").should eq("PushVar foo;")
+  end
+
+  it "parses '-foo'" do
+    compile("-foo").should eq("PushInvertion;PushVar foo;")
+  end
+
+  it "parses 'foo[-42]'" do
+    compile("foo[-42]").should eq("PushVar foo;PushLiteral -42;IndexCall;")
+  end
+
+  it "parses 'foo[42]'" do
+    compile("foo[42]").should eq("PushVar foo;PushLiteral 42;IndexCall;")
+  end
+
+  it "parses '!foo'" do
+    compile("!foo").should eq("PushNegation;PushVar foo;")
+  end
+
+  it "parses 'foo.bar'" do
+    compile("foo.bar").should eq("PushVar foo;Call bar;")
+  end
+
+  it "parses 'foo.bar.hey'" do
+    compile("foo.bar.hey").should eq("PushVar foo;Call bar;Call hey;")
+  end
+
+  it "parses 'foo[0]'" do
+    compile("foo[0]").should eq("PushVar foo;PushLiteral 0;IndexCall;")
+  end
+
+  it "parses 'foo[hey]'" do
+    compile("foo[hey]").should eq("PushVar foo;PushVar hey;IndexCall;")
+  end
+
+  it "parses 'foo[\"hey\"]'" do
+    compile("foo[\"hey\"]").should eq("PushVar foo;PushLiteral hey;IndexCall;")
+  end
+
+  it "parses 'foo[hey.ho]'" do
+    compile("foo[hey.ho]").should eq("PushVar foo;PushVar hey;Call ho;IndexCall;")
+  end
+
+  it "parses 'foo[hey.ho[foo[2]]'" do
+    compile("foo[hey.ho[foo[2]]").should eq("PushVar foo;PushVar hey;Call ho;PushVar foo;PushLiteral 2;IndexCall;IndexCall;")
+  end
+
+  it "parses 'foo[2].bar'" do
+    compile("foo[2].bar").should eq("PushVar foo;PushLiteral 2;IndexCall;Call bar;")
+  end
+
+  it "evaluate 'foo'" do
+    evaluate("foo", Hash{"foo" => Any.new(42)}).should eq(Any.new(42))
+  end
+
+  it "evaluate 'bar', not in context" do
+    expect_raises(KeyError, "Key \"bar\" not found") do
+      evaluate("bar", Hash{"foo" => Any.new(42)})
+    end
+  end
+
+  it "evaluate 'foo.blank?'" do
+    evaluate("foo.blank?", Hash{"foo" => Any.new("")}).should eq(Any.new(true))
+  end
+
+  it "evaluate 'foo.size'" do
+    evaluate("foo.size", Hash{"foo" => Any.new("123")}).should eq(Any.new(3))
+  end
+
+  it "evaluate 'foo[0]'" do
+    evaluate("foo[0]", Hash{"foo" => Any{42}}).should eq(Any.new(42))
+  end
+
+  it "evaluate 'foo[hey]'" do
+    evaluate("foo[hey]", Hash{"foo" => Any{"bar" => "ok"}, "hey" => Any.new("bar")}).should eq(Any.new("ok"))
+  end
+
+  it "evaluate 'foo[\"bar\"]'" do
+    evaluate("foo[\"bar\"]", Hash{"foo" => Any{"bar" => "ok"}}).should eq(Any.new("ok"))
+  end
+
+  it "evaluate 'foo[hey.ho]'" do
+    evaluate("foo[hey.ho]", Hash{"foo" => Any{Any.new(true)}, "hey" => Any{"ho" => 0}}).should eq(Any.new(true))
+  end
+
+  context "when foo is a Drop" do
+    it "evaluate 'drop.text'" do
+      evaluate("drop.text", Hash{"drop" => Any.new(TextDrop.new)}).should eq(Any.new("text from drop"))
+    end
+
+    it "evaluate 'drop[\"text\"]'" do
+      evaluate("drop[\"text\"]", Hash{"drop" => Any.new(TextDrop.new)}).should eq(Any.new("text from drop"))
+    end
+
+    it "evaluate 'product.texts.array[1]'" do
+      evaluate("product.texts.array[1]", Hash{"product" => Any.new(ProductDrop.new)}).should eq(Any.new("text1"))
+    end
+
+    it "evaluate 'drop.text' when Drop inherits another Drop" do
+      evaluate("drop.text", Hash{"drop" => Any.new(SuperTextDrop.new)}).should eq(Any.new("text from drop"))
+    end
+
+    it "doesn't export private methods" do
+      expect_raises(Exception, "Method private_method not found for TextDrop.") do
+        evaluate("drop.private_method", Hash{"drop" => Any.new(TextDrop.new)})
+      end
+    end
+
+    it "doesn't export protected methods" do
+      expect_raises(Exception, "Method protected_method not found for TextDrop.") do
+        evaluate("drop.protected_method", Hash{"drop" => Any.new(TextDrop.new)})
+      end
+    end
+  end
+end

--- a/spec/template_spec.cr
+++ b/spec/template_spec.cr
@@ -96,6 +96,25 @@ describe Template do
     tpl.render(ctx).should eq "We are somewhere"
   end
 
+  it "should render case statement with strip" do
+    tpl = Parser.parse <<-EOT
+    Hey...
+    {%- case var %}
+    {% when "here" -%}
+    We are here
+    {%- else -%}
+    We are somewhere
+    {%- endcase %}
+    EOT
+    ctx = Context.new
+    ctx.set("var", "here")
+    tpl.render(ctx).should eq "Hey...We are here"
+    ctx.set("var", "there")
+    tpl.render(ctx).should eq "Hey...We are somewhere"
+    ctx.set("var", "")
+    tpl.render(ctx).should eq "Hey...We are somewhere"
+  end
+
   it "should render if statement" do
     tpl = Parser.parse("{% if var == true %}true{% endif %}")
     ctx = Context.new

--- a/spec/template_spec.cr
+++ b/spec/template_spec.cr
@@ -313,7 +313,7 @@ describe Template do
     tpl.render(ctx).should eq ""
   end
 
-  it "should support #blank?" do
+  pending "should support #blank?" do
     tpl = Template.parse %({% if var.blank? %}blank{% endif %})
     ctx = Context{"var" => "12345678"}
     tpl.render(ctx).should eq ""

--- a/src/liquid.cr
+++ b/src/liquid.cr
@@ -13,3 +13,8 @@ require "./liquid/version"
 require "./liquid/visitor"
 require "./liquid/codegen_visitor"
 require "./liquid/render_visitor"
+
+module Liquid
+  class Exception < RuntimeError
+  end
+end

--- a/src/liquid/any.cr
+++ b/src/liquid/any.cr
@@ -1,6 +1,8 @@
+require "./drop"
+
 module Liquid
   struct Any
-    alias Type = Nil | Bool | Int32 | Int64 | Float32 | Float64 | String | Time | Array(Any) | Hash(String, Any)
+    alias Type = Nil | Bool | Int32 | Int64 | Float32 | Float64 | String | Time | Array(Any) | Hash(String, Any) | Drop
 
     # Returns the raw underlying value.
     getter raw : Type
@@ -248,6 +250,13 @@ module Liquid
 
     def inspect(io : IO) : Nil
       @raw.inspect(io)
+    end
+
+    def -
+      raw = @raw
+      raise Exception.new("Can't apply '-' operator to #{raw.class.name}") unless raw.is_a?(Number)
+
+      Any.new(-raw)
     end
 
     def to_s(io : IO) : Nil

--- a/src/liquid/blocks/block.cr
+++ b/src/liquid/blocks/block.cr
@@ -1,20 +1,10 @@
 require "../visitor"
 
 module Liquid::Block
-  enum BlockType
-    Inline
-    Begin
-    End
-    Raw
-    RawHidden
-  end
-
-  abstract def type : BlockType
-
   abstract class Node
-    getter children
-    @children : Array(Node)
-    @children = Array(Node).new
+    getter children = Array(Node).new
+    property? rstrip = false
+    property? lstrip = false
 
     abstract def initialize(content : String)
 
@@ -39,41 +29,23 @@ module Liquid::Block
 
   abstract class InlineBlock < Node
     extend Block
-
-    def self.type : BlockType
-      BlockType::Inline
-    end
   end
 
   abstract class BeginBlock < Node
     extend Block
-
-    def self.type : BlockType
-      BlockType::Begin
-    end
   end
 
-  abstract class EndBlock < Node
+  class EndBlock < Node
     extend Block
 
-    def self.type : BlockType
-      BlockType::End
+    def initialize(content)
+    end
+
+    def initialize
     end
   end
 
   abstract class RawBlock < Node
     extend Block
-
-    def self.type : BlockType
-      BlockType::Raw
-    end
-  end
-
-  abstract class RawHiddenBlock < Node
-    extend Block
-
-    def self.type : BlockType
-      BlockType::RawHidden
-    end
   end
 end

--- a/src/liquid/blocks/case.cr
+++ b/src/liquid/blocks/case.cr
@@ -13,11 +13,9 @@ module Liquid::Block
       Else
     end
 
-    getter :case, :case_expression, :else, :when
-
-    @case_expression : Expression?
-    @when : Array(When)?
-    @else : Else?
+    getter case_expression : Expression
+    getter when : Array(When)?
+    getter else : Else?
 
     @last = PutInto::Case
 

--- a/src/liquid/blocks/comment.cr
+++ b/src/liquid/blocks/comment.cr
@@ -1,14 +1,15 @@
 require "./block"
 
 module Liquid::Block
-  class Comment < RawHiddenBlock
-    @content : String
-
-    def initialize(@content)
+  class Comment < BeginBlock
+    def initialize(content : String)
     end
 
     def content
       ""
+    end
+
+    def <<(node : Node)
     end
 
     def_equals @children, content

--- a/src/liquid/blocks/expression.cr
+++ b/src/liquid/blocks/expression.cr
@@ -69,7 +69,7 @@ module Liquid::Block
     INTERNED_GFILTERED   = /^#{GFILTERED}$/
     PARENTHESIZED_SCALAR = /^(#{SCALAR})/
 
-    def eval(data) : Any
+    def eval(data : Context) : Any
       ret = if @var == "true" || @var == "!false"
               true
             elsif @var == "false" || @var == "!true"

--- a/src/liquid/blocks/if.cr
+++ b/src/liquid/blocks/if.cr
@@ -13,11 +13,9 @@ module Liquid::Block
       Else
     end
 
-    getter :else, :elsif, :if_expression
-
-    @if_expression : Expression?
-    @elsif : Array(ElsIf)?
-    @else : Else?
+    getter if_expression : Expression
+    getter elsif : Array(ElsIf)?
+    getter else : Else?
 
     @last = PutInto::If
 

--- a/src/liquid/blocks/raw.cr
+++ b/src/liquid/blocks/raw.cr
@@ -9,6 +9,22 @@ module Liquid::Block
     def initialize(@content)
     end
 
+    def rstrip=(value : Bool)
+      raise InvalidStatement.new("Raw tags can not have whitespace controls.") if value
+    end
+
+    def lstrip=(value : Bool)
+      raise InvalidStatement.new("Raw tags can not have whitespace controls.") if value
+    end
+
+    def lstrip!
+      @content = @content.lstrip
+    end
+
+    def rstrip!
+      @content = @content.rstrip
+    end
+
     def_equals @children, @content
   end
 end

--- a/src/liquid/context.cr
+++ b/src/liquid/context.cr
@@ -1,226 +1,23 @@
 require "./any"
+require "./stack_machine"
 
 module Liquid
   struct Context
     @inner : Hash(String, Any)
-    property strict : Bool = false
+
+    property strict : Bool
 
     def initialize(@strict = false)
       @inner = Hash(String, Any).new
       self["empty"] = [] of Any
     end
 
-    def parse_error(key, strict : Bool, message : String? = nil)
-      message ||= "Parse error: \"#{key}\""
-      if strict
-        raise Exception.new(message)
-      else
-        nil
-      end
-    end
+    def get(expr, strict : Bool = @strict) : Any?
+      StackMachine.new(expr).evaluate(@inner)
+    rescue e : Exception | KeyError
+      raise e if strict
 
-    def index_error(key, strict : Bool)
-      if strict
-        raise IndexError.new("Array index out of bounds: \"#{key}\"")
-      else
-        nil
-      end
-    end
-
-    def key_missing(key, strict : Bool)
-      if strict
-        raise KeyError.new("Key does not exist in context: \"#{key}\"")
-      else
-        nil
-      end
-    end
-
-    STRING_OR_INT_OR_VAR = /\[((#{STRING})|(#{INT})|(#{VAR}))\]/
-    NEGATIVE_INT         = /^(\-?#{INT})$/
-    NEGATIVE_VAR         = /^\-?(#{VAR})$/
-
-    # key can include . (property/method access) and/or [] (array index)
-    @[AlwaysInline]
-    def get(key, strict : Bool = @strict)
-      if key =~ /^(.*?)\?$/
-        key = $1
-        strict = false
-      end
-
-      return @inner[key] if @inner.has_key?(key)
-
-      prefixes = [] of String
-      if key =~ /^([-!]+)(.*?)$/
-        prefixes = $1.split(//)
-        key = $2
-      end
-
-      segments = key.split(".", remove_empty: false)
-
-      # there should not be any blank segments (e.g. asdf..fdsa, .asdf, asdf.)
-      return parse_error(key, strict) if segments.any?(&.blank?)
-
-      # rejoin any segments that got broken in the middle of an array index
-      segments.each_with_index do |segment, i|
-        if segment.includes?("[") && !segment.includes?("]")
-          # join until we find the closing bracket
-          (i + 1...segments.size).each do |j|
-            str = segments[j]
-            segments[j] = ""
-            segments[i] = "#{segments[i]}.#{str}"
-            break if str.includes?("]") # found the closing bracket
-          end
-        end
-      end
-
-      # remove any segments that are now blank
-      segments.reject!(&.blank?)
-
-      ret : Any? = nil
-
-      segments.each do |k|
-        next unless k
-
-        # ignore array index/hash key if present, first handle methods/properties
-        bracket_index = k.index('[')
-        name =
-          if bracket_index && k.ends_with?(']')
-            k[0...bracket_index]
-          else
-            k
-          end
-
-        if ret
-          # handle a selection of convenience methods
-          # wrap values in Any to make sure the return type is always the same
-          case name
-          when "present"
-            if (array = ret.as_a?)
-              ret = Any.new(array.size > 0)
-            elsif (hash = ret.as_h?)
-              ret = Any.new(hash.keys.size > 0)
-            else
-              ret = Any.new(ret.raw.to_s.size > 0)
-            end
-          when "blank"
-            if (array = ret.as_a?)
-              ret = Any.new(array.size == 0)
-            elsif (hash = ret.as_h?)
-              ret = Any.new(hash.keys.size == 0)
-            else
-              ret = Any.new(ret.raw.to_s.size == 0)
-            end
-          when "size"
-            if (array = ret.as_a?)
-              ret = Any.new(array.size)
-            elsif (hash = ret.as_h?)
-              ret = Any.new(hash.keys.size)
-            elsif (str = ret.as_s?)
-              ret = Any.new(str.size)
-            else
-              return parse_error(key, strict, "Parse error: Tried to call #size on something other than a String, Array or Hash (#{key} -> #{ret.inspect})")
-            end
-          else
-            # if not a method, then it's a property (implemented as JSON hash member)
-            if (hash = ret.as_h?)
-              return key_missing(key, strict) unless hash.has_key?(k)
-
-              ret = hash[k]
-            else
-              return parse_error(key, strict, "Parse error: Tried to access property of a non-hash object (#{key} -> #{ret.inspect})")
-            end
-          end
-        else
-          # first time through ret = nil, name should correspond to a top level key in @inner
-          if @inner.has_key?(name)
-            ret = @inner[name]
-          else
-            if strict
-              return key_missing(key, strict)
-            else
-              # keep going, in case we're ultimately just doing a #blank check
-              ret = Any.new(nil)
-            end
-          end
-        end
-
-        while k =~ STRING_OR_INT_OR_VAR
-          index = $1
-          # puts index
-          if (index =~ NEGATIVE_INT) && (idx = $1.to_i?) && ret && (array = ret.as_a?)
-            # array access via integer literal
-            return index_error(key, strict) unless (-array.size..array.size).includes?(idx)
-
-            ret = array[idx]
-            k = k.sub("[#{index}]", "")
-          elsif (match = index.match(GSTRING)) && ret && (hash = ret.as_h?)
-            # hash access via string literal
-            hashkey = match["str"]
-            if hash.has_key?(hashkey)
-              ret = hash[hashkey]
-            else
-              return key_missing(key, strict)
-            end
-
-            k = k.sub("[#{index}]", "")
-          elsif (index =~ NEGATIVE_VAR) && (varname = $1) && ret && (array = ret.as_a?)
-            # array access via integer variable
-            invert = (index[0] == '-')
-            if (realidx = self[varname]?.try(&.as_i?))
-              realidx *= invert ? -1 : 1
-              return index_error(key, strict) unless (-array.size..array.size).includes?(realidx)
-
-              ret = array[realidx]
-              k = k.sub("[#{index}]", "")
-            else
-              return key_missing(key, strict)
-            end
-          elsif (varname = index) && ret && (hash = ret.as_h?)
-            # hash access via string variable
-            if (realkey = self[varname]?.try(&.as_s?))
-              return key_missing(key, strict) unless hash.has_key?(realkey)
-
-              ret = hash[realkey]
-              k = k.sub("[#{index}]", "")
-            else
-              return parse_error(key, strict, "#{key}: Could not resolve hash key `#{varname}` to String value")
-            end
-          else
-            # hmm, we failed to match any known indexing scheme
-            return parse_error(key, strict)
-          end
-        end
-      end
-
-      # apply prefixes in reverse order
-      prefixes.reverse.each do |prefix|
-        case prefix
-        when "-"
-          if ret && ((num = ret.as_i?) || (num = ret.as_f?))
-            ret = Any.new(-1 * num)
-          else
-            return parse_error(key, true, "Parse error: Couldn't interpret #{ret.inspect} as numeric value (#{key})")
-          end
-        when "!"
-          # booleans are tricky... first, treat nil as false
-          # next, check to see whether it can be interpret as bool (check for nil
-          # specifically, to avoid returning parse error on false value)
-          if ret.nil? || ret.raw.nil?
-            ret = Any.new(true)
-          elsif !(bool = ret.as_bool?).nil?
-            ret = Any.new(!bool)
-          else
-            return parse_error(key, true, "Parse error: Couldn't interpret #{ret.inspect} as boolean value (#{key})")
-          end
-        else
-          return parse_error(key, true, "Parse error: Unknown prefix operator #{prefix}")
-        end
-      end
-
-      # unwrap if it's just a nil inside a Any (note: Expression sometimes re-wraps it)
-      ret = nil if ret && ret.raw.nil?
-
-      ret
+      nil
     end
 
     def [](key : String) : Any

--- a/src/liquid/drop.cr
+++ b/src/liquid/drop.cr
@@ -1,0 +1,31 @@
+require "./any"
+
+module Liquid
+  abstract class Drop
+    macro inherited
+      {% verbatim do %}
+      macro finished
+        def call(method : String) : Liquid::Any
+          case method
+          {% for method in @type.methods %}
+            {% if method.args.size == 0 && method.visibility == :public %}
+              when {{ method.name.stringify }}
+                ret = {{ method.name.id }}
+                ret.is_a?(Liquid::Any) ? ret : Liquid::Any.new(ret)
+            {% end %}
+          {% end %}
+          else
+            super
+          end
+        end
+      end
+      {% end %}
+    end
+
+    # Called by `StackMachine` to call a method from this `Drop`.
+    # Only public methods without parameters can be called here
+    def call(method : String) : Liquid::Any
+      raise Liquid::InvalidExpression.new("Method #{method} not found for #{self.class.name}.")
+    end
+  end
+end

--- a/src/liquid/render_visitor.cr
+++ b/src/liquid/render_visitor.cr
@@ -6,23 +6,11 @@ module Liquid
     @io : IO
     @template_path : String?
 
-    def initialize
-      @data = Context.new
-      @io = IO::Memory.new
+    def initialize(@data = Context.new, @io = IO::Memory.new, @template_path = nil)
     end
 
-    def initialize(@data : Context)
-      @io = IO::Memory.new
-    end
-
-    def initialize(@data : Context, @io : IO)
-    end
-
-    def initialize(@data : Context, @io : IO, @template_path : String?)
-    end
-
+    @[Deprecated]
     def output
-      @io.close
       @io.to_s
     end
 

--- a/src/liquid/stack_machine.cr
+++ b/src/liquid/stack_machine.cr
@@ -1,0 +1,284 @@
+require "string_scanner"
+
+module Liquid
+  # :nodoc:
+  # This is used by `Context` to evaluate expressions like `variable.attribute[0]`
+  struct StackMachine
+    enum Action
+      PushInvertion # Like in -var
+      PushNegation  # Like in !var
+      PushVar       # Like in var
+      PushLiteral   # Like in "var" or 'var'
+      Call          # Like in var.call
+      IndexCall     # Like in var[index]
+    end
+
+    struct OpCode
+      getter action : Action
+      getter! value : String?
+
+      def initialize(@action, @value = nil)
+      end
+
+      def to_s(io : IO)
+        io << action
+        io << ' ' << @value if @value
+        io << ';'
+      end
+    end
+
+    @expr : String
+    @opcodes : Array(OpCode)?
+
+    def initialize(@expr : String)
+    end
+
+    def compile : Array(OpCode)
+      opcodes = @opcodes
+      return opcodes unless opcodes.nil?
+
+      @opcodes = opcodes = [] of OpCode
+      scanner = StringScanner.new(@expr)
+      calling_method = false
+
+      loop do
+        scanner.skip(/\s*/)
+        break if scanner.eos?
+
+        next_char = @expr[scanner.offset]
+        case next_char
+        when '.'
+          calling_method = true
+          scanner.offset += 1
+        when '-'
+          value = scanner.scan(/-?\d+/)
+          if value
+            opcodes << OpCode.new(:push_literal, value)
+          else
+            opcodes << OpCode.new(:push_invertion)
+            scanner.offset += 1
+          end
+        when .ascii_number?
+          value = scanner.scan(/\d+/)
+          opcodes << OpCode.new(:push_literal, value)
+        when '!'
+          scanner.offset += 1
+          opcodes << OpCode.new(:push_negation)
+        when '['
+          scanner.offset += 1
+        when ']'
+          scanner.offset += 1
+          opcodes << OpCode.new(:index_call)
+        when '"', '\''
+          value = parse_string(scanner, next_char)
+          opcodes << OpCode.new(:push_literal, value)
+        else
+          value = scanner.scan(/\w+\??/)
+          raise Exception.new("Expecting a word, got #{@expr[scanner.offset]}.") if value.nil?
+
+          if calling_method
+            calling_method = false
+            opcodes << OpCode.new(:call, value)
+          else
+            opcodes << OpCode.new(:push_var, value)
+          end
+        end
+      end
+      opcodes
+    end
+
+    private def parse_string(scanner : StringScanner, limit : Char) : String
+      reader = Char::Reader.new(scanner.string, scanner.offset + 1)
+      parse_completed = false
+      string = String.build do |str|
+        handling_escape = false
+
+        reader.each do |char|
+          if handling_escape
+            handle_escape_sequence(char, limit, str)
+            handling_escape = false
+          elsif char == '\\'
+            handling_escape = true
+          elsif char == limit
+            parse_completed = true
+            break
+          else
+            str << char
+          end
+        end
+
+        if parse_completed
+          next
+        else
+          raise Exception.new("Unterminated string literal.")
+        end
+      end
+
+      scanner.offset = reader.pos + 1
+      string
+    end
+
+    private def handle_escape_sequence(char : Char, limit : Char, str : IO)
+      case char
+      when 'n'
+        str << '\n'
+      when 't'
+        str << '\t'
+      when limit
+        str << limit
+      else
+        str << '\\' << char
+      end
+    end
+
+    def reset
+      @opcodes.clear
+    end
+
+    private enum Prefix
+      Invert
+      Negate
+    end
+
+    alias Stack = Deque(Any | String | Prefix)
+
+    def evaluate(vars : Hash(String, Any)) : Any
+      # Fast path for single variables
+      value = vars[@expr]?
+      return value if value
+
+      opcodes = compile
+      stack = Stack.new
+      compile.each do |opcode|
+        case opcode.action
+        in .push_var?
+          value = vars[opcode.value]?
+          value ||= if opcode.value.ends_with?('?')
+                      vars[opcode.value.rchop]? || Any.new(nil)
+                    elsif opcode.value.to_i?
+                      opcode.value
+                    else
+                      raise KeyError.new("Key \"#{opcode.value}\" not found.")
+                    end
+          stack.push(value)
+        in .push_invertion?
+          stack.push(Prefix::Invert)
+        in .push_negation?
+          stack.push(Prefix::Negate)
+        in .push_literal?
+          stack.push(opcode.value)
+        in .call?
+          var = stack.pop.as(Any)
+          stack.push(call_method(var, opcode.value))
+        in .index_call?
+          index = stack.pop
+          var = stack.pop
+          raise Exception.new("Unexpected prefix: #{index}") if index.is_a?(Prefix)
+          raise Exception.new("Unexpected prefix: #{var}") if var.is_a?(Prefix)
+          raise Exception.new("Unexpected string literal: #{var}") if var.is_a?(String)
+
+          var = apply_prefix(var, stack)
+          stack.push(call_index(var, index))
+        end
+      end
+
+      return Any.new(nil) if stack.empty?
+
+      apply_prefix(stack.pop, stack)
+    end
+
+    private def apply_prefix(any : Any, stack : Stack)
+      loop do
+        prefix = stack.last?
+        break unless prefix.is_a?(Prefix)
+
+        any = case prefix
+              in .negate? then Any.new(!any.raw)
+              in .invert? then -any
+              end
+        stack.pop
+      end
+      any
+    end
+
+    private def apply_prefix(str : String, stack : Stack)
+      apply_prefix(Any.new(str), stack)
+    end
+
+    private def apply_prefix(_prefix : Prefix, stack : Stack)
+      raise Exception.new("Unexpected prefix.")
+    end
+
+    private def call_index(any : Any, index : String) : Any
+      raw = any.raw
+      return call_hash_method(raw, index) if raw.is_a?(Hash)
+      return call_drop_method(raw, index) if raw.is_a?(Drop)
+
+      raise Exception.new("Tried to index a non-array object with \"#{index}\".") unless raw.is_a?(Array)
+
+      i = index.to_i?
+      raise Exception.new("Tried to index an array object with a #{raw.class.name}.") if i.nil?
+
+      raw[i]? || raise Exception.new("\"Index out of bounds: #{i}.")
+    end
+
+    private def call_index(any : Any, index : Any) : Any
+      raw = any.raw
+      return call_hash_method(raw, index.to_s) if raw.is_a?(Hash)
+
+      raise Exception.new("Tried to index a non-array object with \"#{index}\".") unless raw.is_a?(Array)
+
+      i = index.as_i?
+      raise Exception.new("Tried to index an array object with a #{raw.class.name}.") if i.nil?
+
+      raw[i]? || raise Exception.new("\"Index out of bounds: #{i}.")
+    end
+
+    private def call_method(any : Any, method : String) : Any
+      raw = any.raw
+      return call_drop_method(raw, method) if raw.is_a?(Drop)
+      return call_hash_method(raw, method) if raw.is_a?(Hash)
+
+      if !raw.responds_to?(:size) || raw.nil?
+        raise Exception.new("Tried to call ##{method} on a #{raw.class.name}.")
+      end
+
+      case method
+      when "present", "present?"
+        Any.new(raw.size > 0)
+      when "blank", "blank?"
+        Any.new(raw.try(&.size.zero?))
+      when "size"
+        Any.new(raw.size)
+      else
+        raise Exception.new("Tried to access property \"#{method}\" of a non-hash/non-drop object.")
+      end
+    end
+
+    private def call_drop_method(drop : Drop, method : String) : Any
+      drop.call(method)
+    end
+
+    private def call_hash_method(hash : Hash, method : String) : Any
+      case method
+      when "present", "present?"
+        Any.new(hash.size > 0)
+      when "blank", "blank?"
+        Any.new(hash.size.zero?)
+      when "size"
+        Any.new(hash.size)
+      else
+        value = hash[method]?
+        raise KeyError.new("Key \"#{method}\" not found.") if value.nil?
+
+        value
+      end
+    end
+
+    def to_s(io : IO)
+      compile.each do |instr|
+        io << instr
+      end
+    end
+  end
+end

--- a/src/liquid/strip_visitor.cr
+++ b/src/liquid/strip_visitor.cr
@@ -1,0 +1,41 @@
+module Liquid
+  class StripVisitor < Visitor
+    @last_raw_node : Block::Raw?
+    @lstrip_next_raw_node = false
+
+    private def check_strip(node : Node)
+      last_raw_node = @last_raw_node
+      last_raw_node.rstrip! if last_raw_node && node.lstrip?
+      @lstrip_next_raw_node = node.rstrip?
+    end
+
+    def visit(node : Node)
+      check_strip(node)
+      node.children.each(&.accept(self))
+    end
+
+    def visit(node : If)
+      check_strip(node)
+      node.children.each(&.accept(self))
+      node_elsif = node.elsif
+      node_elsif.each(&.accept(self)) if node_elsif
+      node.else.try(&.accept(self))
+    end
+
+    def visit(node : Case)
+      check_strip(node)
+      node.children.each(&.accept(self))
+      node_when = node.when
+      node_when.each(&.accept(self)) if node_when
+      node.else.try(&.accept(self))
+    end
+
+    def visit(node : Block::Raw)
+      if @lstrip_next_raw_node
+        node.lstrip!
+        @lstrip_next_raw_node = false
+      end
+      @last_raw_node = node
+    end
+  end
+end

--- a/src/liquid/template.cr
+++ b/src/liquid/template.cr
@@ -22,10 +22,15 @@ module Liquid
     def initialize(@root : Block::Root, @template_path : String)
     end
 
-    def render(data, io = IO::Memory.new)
+    def render(data, io : IO) : Nil
       visitor = RenderVisitor.new data, io, @template_path
       visitor.visit @root
-      visitor.output
+    end
+
+    def render(data) : String
+      io = IO::Memory.new
+      render(data, io)
+      io.to_s
     end
 
     def to_code(io_name : String, io : IO = IO::Memory.new, context : String? = nil)

--- a/src/liquid/token.cr
+++ b/src/liquid/token.cr
@@ -1,0 +1,49 @@
+module Liquid
+  struct Token
+    enum Kind
+      Raw
+      Expression
+      Statement
+    end
+
+    getter value : String
+    getter raw_value : String
+    getter line_number : Int32
+    getter kind : Kind
+    getter? lstrip : Bool
+    getter? rstrip : Bool
+
+    def initialize(@raw_value : String, @line_number)
+      if @raw_value.starts_with?("{{")
+        @kind = Kind::Expression
+        @lstrip = should_lstrip?
+        @rstrip = should_rstrip?
+        @value = strip_markup(@raw_value)
+      elsif @raw_value.starts_with?("{%")
+        @kind = Kind::Statement
+        @lstrip = should_lstrip?
+        @rstrip = should_rstrip?
+        @value = strip_markup(@raw_value)
+      else
+        @kind = Kind::Raw
+        @lstrip = false
+        @rstrip = false
+        @value = @raw_value
+      end
+    end
+
+    private def should_lstrip?
+      @raw_value[2] == '-'
+    end
+
+    private def should_rstrip?
+      @raw_value[-3] == '-'
+    end
+
+    private def strip_markup(value : String)
+      i = @lstrip ? 3 : 2
+      j = @rstrip ? -3 : -2
+      value[i...j]
+    end
+  end
+end

--- a/src/liquid/tokenizer.cr
+++ b/src/liquid/tokenizer.cr
@@ -1,0 +1,52 @@
+# Copyright (c) 2022 Acumera Inc
+# Copyright (c) 2005, 2006 Tobias Luetke
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+require "./token"
+
+module Liquid
+  class Tokenizer
+    TagStart              = /(?<!\\)\{\%/
+    TagEnd                = /\%\}/
+    VariableSegment       = /[\w\-]/
+    VariableStart         = /(?<!\\)\{\{/
+    VariableEnd           = /\}\}/
+    VariableIncompleteEnd = /\}\}?/
+    QuotedString          = /"[^"]*"|'[^']*'/
+    QuotedFragment        = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/
+    TagAttributes         = /(\w[\w-]*)\s*\:\s*(#{QuotedFragment})/
+    AnyStartingTag        = /#{TagStart}|#{VariableStart}/
+    PartialTemplateParser = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/m
+    TemplateParser        = /(#{PartialTemplateParser}|#{AnyStartingTag})/m
+    VariableParser        = /\[[^\]]+\]|#{VariableSegment}+\??/
+
+    def self.parse(string : String) : Nil
+      line_number = 1
+
+      string.split(TemplateParser) do |value|
+        next if value.empty?
+
+        yield(Token.new(value, line_number))
+        line_number += string.count('\n')
+      end
+    end
+  end
+end


### PR DESCRIPTION
~This still a draft.~

All public methods with no arguments from a Drop is exported. I implemented a small stack machine to be able to process the expressions given to the Context, but it still missing some things:

- ~The `!` and `-` prefixes aren't implemented yet~
- I'm not 100% sure of the `.blank?` and `.missing?` semantics.
- I need to review the code too, since I believe it can be even simpler.

~Besides two tests about `!` and `-` prefix, these are the tests that still failing.~

```
  1) Liquid Liquid::Context returns nil for missing key in strict mode with ?
     Failure/Error: ctx.get("missing?").should be_nil

       Expected: false to be nil

     # spec/liquid_spec.cr:55

  2) Liquid::Template should support array access via literal
     Failure/Error: tpl.render(ctx).should eq "second, first, third, third"

       Expected: "second, first, third, third"
            got: "second, first, , third"

     # spec/template_spec.cr:238

  3) Liquid::Template should support #blank?
     Failure/Error: tpl.render(ctx).should eq "blank"

       Expected: "blank"
            got: ""

     # spec/template_spec.cr:290

  4) Liquid::Template should support combinations of array/hash access and property access
     Failure/Error: tpl.render(ctx).should eq "3 2 second-b val val val"

       Expected: "3 2 second-b val val val"
            got: "3 2 second-b  val val"

     # spec/template_spec.cr:332
```

Most, if not all, are about how the built in methods `.size`, '.blank`, `present` must behave.

Any early feedback are appreciated.


Fix #36