### PR TITLE
Rewrite the parser using regular expressions.

### DIFF
--- a/spec/template_spec.cr
+++ b/spec/template_spec.cr
@@ -96,6 +96,25 @@ describe Template do
     tpl.render(ctx).should eq "We are somewhere"
   end
 
+  it "should render case statement with strip" do
+    tpl = Parser.parse <<-EOT
+    Hey...
+    {%- case var %}
+    {% when "here" -%}
+    We are here
+    {%- else -%}
+    We are somewhere
+    {%- endcase %}
+    EOT
+    ctx = Context.new
+    ctx.set("var", "here")
+    tpl.render(ctx).should eq "Hey...We are here"
+    ctx.set("var", "there")
+    tpl.render(ctx).should eq "Hey...We are somewhere"
+    ctx.set("var", "")
+    tpl.render(ctx).should eq "Hey...We are somewhere"
+  end
+
   it "should render if statement" do
     tpl = Parser.parse("{% if var == true %}true{% endif %}")
     ctx = Context.new

--- a/src/liquid/blocks/block.cr
+++ b/src/liquid/blocks/block.cr
@@ -1,20 +1,10 @@
 require "../visitor"
 
 module Liquid::Block
-  enum BlockType
-    Inline
-    Begin
-    End
-    Raw
-    RawHidden
-  end
-
-  abstract def type : BlockType
-
   abstract class Node
-    getter children
-    @children : Array(Node)
-    @children = Array(Node).new
+    getter children = Array(Node).new
+    property? rstrip = false
+    property? lstrip = false
 
     abstract def initialize(content : String)
 
@@ -39,41 +29,23 @@ module Liquid::Block
 
   abstract class InlineBlock < Node
     extend Block
-
-    def self.type : BlockType
-      BlockType::Inline
-    end
   end
 
   abstract class BeginBlock < Node
     extend Block
-
-    def self.type : BlockType
-      BlockType::Begin
-    end
   end
 
-  abstract class EndBlock < Node
+  class EndBlock < Node
     extend Block
 
-    def self.type : BlockType
-      BlockType::End
+    def initialize(content)
+    end
+
+    def initialize
     end
   end
 
   abstract class RawBlock < Node
     extend Block
-
-    def self.type : BlockType
-      BlockType::Raw
-    end
-  end
-
-  abstract class RawHiddenBlock < Node
-    extend Block
-
-    def self.type : BlockType
-      BlockType::RawHidden
-    end
   end
 end

--- a/src/liquid/blocks/case.cr
+++ b/src/liquid/blocks/case.cr
@@ -13,11 +13,9 @@ module Liquid::Block
       Else
     end
 
-    getter :case, :case_expression, :else, :when
-
-    @case_expression : Expression?
-    @when : Array(When)?
-    @else : Else?
+    getter case_expression : Expression
+    getter when : Array(When)?
+    getter else : Else?
 
     @last = PutInto::Case
 

--- a/src/liquid/blocks/comment.cr
+++ b/src/liquid/blocks/comment.cr
@@ -1,14 +1,15 @@
 require "./block"
 
 module Liquid::Block
-  class Comment < RawHiddenBlock
-    @content : String
-
-    def initialize(@content)
+  class Comment < BeginBlock
+    def initialize(content : String)
     end
 
     def content
       ""
+    end
+
+    def <<(node : Node)
     end
 
     def_equals @children, content

--- a/src/liquid/blocks/if.cr
+++ b/src/liquid/blocks/if.cr
@@ -13,11 +13,9 @@ module Liquid::Block
       Else
     end
 
-    getter :else, :elsif, :if_expression
-
-    @if_expression : Expression?
-    @elsif : Array(ElsIf)?
-    @else : Else?
+    getter if_expression : Expression
+    getter elsif : Array(ElsIf)?
+    getter else : Else?
 
     @last = PutInto::If
 

--- a/src/liquid/blocks/raw.cr
+++ b/src/liquid/blocks/raw.cr
@@ -9,6 +9,22 @@ module Liquid::Block
     def initialize(@content)
     end
 
+    def rstrip=(value : Bool)
+      raise InvalidStatement.new("Raw tags can not have whitespace controls.") if value
+    end
+
+    def lstrip=(value : Bool)
+      raise InvalidStatement.new("Raw tags can not have whitespace controls.") if value
+    end
+
+    def lstrip!
+      @content = @content.lstrip
+    end
+
+    def rstrip!
+      @content = @content.rstrip
+    end
+
     def_equals @children, @content
   end
 end

--- a/src/liquid/strip_visitor.cr
+++ b/src/liquid/strip_visitor.cr
@@ -1,0 +1,41 @@
+module Liquid
+  class StripVisitor < Visitor
+    @last_raw_node : Block::Raw?
+    @lstrip_next_raw_node = false
+
+    private def check_strip(node : Node)
+      last_raw_node = @last_raw_node
+      last_raw_node.rstrip! if last_raw_node && node.lstrip?
+      @lstrip_next_raw_node = node.rstrip?
+    end
+
+    def visit(node : Node)
+      check_strip(node)
+      node.children.each(&.accept(self))
+    end
+
+    def visit(node : If)
+      check_strip(node)
+      node.children.each(&.accept(self))
+      node_elsif = node.elsif
+      node_elsif.each(&.accept(self)) if node_elsif
+      node.else.try(&.accept(self))
+    end
+
+    def visit(node : Case)
+      check_strip(node)
+      node.children.each(&.accept(self))
+      node_when = node.when
+      node_when.each(&.accept(self)) if node_when
+      node.else.try(&.accept(self))
+    end
+
+    def visit(node : Block::Raw)
+      if @lstrip_next_raw_node
+        node.lstrip!
+        @lstrip_next_raw_node = false
+      end
+      @last_raw_node = node
+    end
+  end
+end

--- a/src/liquid/token.cr
+++ b/src/liquid/token.cr
@@ -1,0 +1,49 @@
+module Liquid
+  struct Token
+    enum Kind
+      Raw
+      Expression
+      Statement
+    end
+
+    getter value : String
+    getter raw_value : String
+    getter line_number : Int32
+    getter kind : Kind
+    getter? lstrip : Bool
+    getter? rstrip : Bool
+
+    def initialize(@raw_value : String, @line_number)
+      if @raw_value.starts_with?("{{")
+        @kind = Kind::Expression
+        @lstrip = should_lstrip?
+        @rstrip = should_rstrip?
+        @value = strip_markup(@raw_value)
+      elsif @raw_value.starts_with?("{%")
+        @kind = Kind::Statement
+        @lstrip = should_lstrip?
+        @rstrip = should_rstrip?
+        @value = strip_markup(@raw_value)
+      else
+        @kind = Kind::Raw
+        @lstrip = false
+        @rstrip = false
+        @value = @raw_value
+      end
+    end
+
+    private def should_lstrip?
+      @raw_value[2] == '-'
+    end
+
+    private def should_rstrip?
+      @raw_value[-3] == '-'
+    end
+
+    private def strip_markup(value : String)
+      i = @lstrip ? 3 : 2
+      j = @rstrip ? -3 : -2
+      value[i...j]
+    end
+  end
+end

--- a/src/liquid/tokenizer.cr
+++ b/src/liquid/tokenizer.cr
@@ -1,0 +1,52 @@
+# Copyright (c) 2020 Acumera Inc
+# Copyright (c) 2005, 2006 Tobias Luetke
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+require "./token"
+
+module Liquid
+  class Tokenizer
+    TagStart              = /(?<!\\)\{\%/
+    TagEnd                = /\%\}/
+    VariableSegment       = /[\w\-]/
+    VariableStart         = /(?<!\\)\{\{/
+    VariableEnd           = /\}\}/
+    VariableIncompleteEnd = /\}\}?/
+    QuotedString          = /"[^"]*"|'[^']*'/
+    QuotedFragment        = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/
+    TagAttributes         = /(\w[\w-]*)\s*\:\s*(#{QuotedFragment})/
+    AnyStartingTag        = /#{TagStart}|#{VariableStart}/
+    PartialTemplateParser = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/m
+    TemplateParser        = /(#{PartialTemplateParser}|#{AnyStartingTag})/m
+    VariableParser        = /\[[^\]]+\]|#{VariableSegment}+\??/
+
+    def self.parse(string : String) : Nil
+      line_number = 1
+
+      string.split(TemplateParser) do |value|
+        next if value.empty?
+
+        yield(Token.new(value, line_number))
+        line_number += string.count('\n')
+      end
+    end
+  end
+end


### PR DESCRIPTION
A tokenizer using regular expressions was added, using the very same regular expressions used by Ruby version of Liquid template.

*Changes*

- A regex-based tokenizer was added.
- The blocks now have the lstrip/rstrip information and strip is made by a visitor after parsing the entire document.
- End blocks are instantiated and part of the node tree now (for strip purposes), so it's not an abstract class anymore.
- Raw tags do not support whitespace controls (like Ruby version).
- Removed BlockType enum, since is simpler to just check the instance type.

This is *much* faster than the current parser for some cases and makes it more compatible with the Ruby version of liquid template, since it's using the same regexes in the tokenizer.

I have a file in production that renders in 200 seconds with Crystal version and milliseconds in Ruby, now with this PR it also renders in milliseconds in Crystal.

It's late here, tomorrow I can send a benchmark with a example file that trigger the slowness.
