### PR TITLE
Do not close output stream on RenderVisitor.

### DIFF
--- a/spec/blocks_spec.cr
+++ b/spec/blocks_spec.cr
@@ -182,51 +182,35 @@ describe Liquid do
     describe Filtered do
       it "should filter a string" do
         node = Filtered.new " \"whatever\" | abs"
-        v = RenderVisitor.new
-        node.accept v
-        v.output.should eq "whatever"
+        node_output(node).should eq "whatever"
       end
 
       it "should filter a int" do
         node = Filtered.new "-12 | abs"
-        v = RenderVisitor.new
-        node.accept v
-        v.output.should eq "12"
+        node_output(node).should eq "12"
       end
 
       it "should filter a float" do
         node = Filtered.new "-12.25 | abs"
-        v = RenderVisitor.new
-        node.accept v
-        v.output.should eq "12.25"
+        node_output(node).should eq "12.25"
       end
 
       it "should filter a var" do
         node = Filtered.new "var | abs"
-        ctx = Context.new
-        ctx.set "var", -12
-        v = RenderVisitor.new ctx
-        node.accept v
-        v.output.should eq "12"
+        ctx = Context{"var" => -12}
+        node_output(node, ctx).should eq "12"
       end
 
       it "should use multiple filters" do
         node = Filtered.new "var | append: \"Hello \" | append: \"World !\""
-        ctx = Context.new
-        ctx.set "var", ""
-        v = RenderVisitor.new ctx
-        node.accept v
-        v.output.should eq "Hello World !"
+        ctx = Context{"var" => ""}
+        node_output(node, ctx).should eq "Hello World !"
       end
 
       it "should filter with an argument" do
         node = Filtered.new "var | append: var2"
-        ctx = Context.new
-        ctx.set "var", "Hello"
-        ctx.set "var2", " World !"
-        v = RenderVisitor.new ctx
-        node.accept v
-        v.output.should eq "Hello World !"
+        ctx = Context{"var" => "Hello", "var2" => " World !"}
+        node_output(node, ctx).should eq "Hello World !"
       end
     end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,8 +3,9 @@ require "../src/liquid"
 
 include Liquid
 
-def node_output(node : Node, ctx : Context)
-  v = RenderVisitor.new ctx, IO::Memory.new
-  node.accept v
-  v.output
+def node_output(node : Node, ctx : Context = Context.new) : String
+  io = IO::Memory.new
+  v = RenderVisitor.new(ctx, io)
+  node.accept(v)
+  io.to_s
 end

--- a/src/liquid/render_visitor.cr
+++ b/src/liquid/render_visitor.cr
@@ -6,23 +6,11 @@ module Liquid
     @io : IO
     @template_path : String?
 
-    def initialize
-      @data = Context.new
-      @io = IO::Memory.new
+    def initialize(@data = Context.new, @io = IO::Memory.new, @template_path = nil)
     end
 
-    def initialize(@data : Context)
-      @io = IO::Memory.new
-    end
-
-    def initialize(@data : Context, @io : IO)
-    end
-
-    def initialize(@data : Context, @io : IO, @template_path : String?)
-    end
-
+    @[Deprecated]
     def output
-      @io.close
       @io.to_s
     end
 

--- a/src/liquid/template.cr
+++ b/src/liquid/template.cr
@@ -22,10 +22,15 @@ module Liquid
     def initialize(@root : Block::Root, @template_path : String)
     end
 
-    def render(data, io = IO::Memory.new)
+    def render(data, io : IO) : Nil
       visitor = RenderVisitor.new data, io, @template_path
       visitor.visit @root
-      visitor.output
+    end
+
+    def render(data) : String
+      io = IO::Memory.new
+      render(data, io)
+      io.to_s
     end
 
     def to_code(io_name : String, io : IO = IO::Memory.new, context : String? = nil)


### PR DESCRIPTION
This deprecates `RenderVisitor#output`, that used to close the output stream then call `.to_s` on it.

Now it only calls `.to_s` and close no stream.

Closing the stream cause problems if using e.g. STDOUT or any stream that you want to continue ussing after the template render.

Another flaw of `RenderVisitor#output` method is that it calls `.to_s` on the `IO` object, but most IO objects don't return the stream contents on `to_s` method.

**API Changes**

- Deprecate `RenderVisitor#output` method.
- Change signature of `Template#render(data, io = IO::Memory.new) : String` to `Template#render(data, io : IO) : Nil`.
- Add `Template#render(data) : String`.
- Modify some tests to use the already existing `node_output` helper function.
- Unify all `RenderVisitor` constructors into a single, source retro-compatible, one.