### PR TITLE
Some love to error handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,21 +161,19 @@ Or on an existing Context:
 ctx.error_mode = :strict
 ```
 
-Raises `Liquid::InvalidExpression` on missing keys or `IndexError` on array out of bounds errors instead of silently emitting `nil`.
+Raises `Liquid::InvalidExpression` on missing keys and silently emit `nil` on array out of bounds.
 
 Append `?` to emit nil in strict mode (very simplistic, just checks for `?` at the end of the identifier)
 
 ```crystal
-ctx = Liquid::Context.new(strict: true)
+ctx = Liquid::Context.new(:strict)
 ctx["obj"] = { something: "something" }
 ```
 
 ```liquid
-{{ missing }}          -> KeyError
-{{ missing? }}         -> nil
-{{ obj.missing }}      -> KeyError
-{{ obj.missing? }}     -> nil
-{{ missing.missing? }} -> nil
+{{ missing }}          -> nil, but generates a UndefinedVariable errors if not in Lax mode.
+{{ obj.missing }}      -> InvalidExpression
+{{ missing.missing? }} -> generates a UndefinedVariable error, evaluates `missing` to nil then raises a InvalidExpression due to `nil.missing` call.
 ```
 
 ## Contributing

--- a/spec/expression_spec.cr
+++ b/spec/expression_spec.cr
@@ -51,8 +51,6 @@ private def it_raises(exception, message : String, expr : String, ctx : Context,
 end
 
 describe Expression do
-  it_raises(InvalidExpression, "Variable \"bar\" not found", "bar", Context.new(:strict))
-
   it_evaluates("foo", Context{"foo" => 42}, 42)
   it_evaluates("foo.blank?", Context{"foo" => ""}, true)
   it_evaluates("foo.size", Context{"foo" => Any.new("123")}, 3)

--- a/spec/integration/integration_spec.cr
+++ b/spec/integration/integration_spec.cr
@@ -16,7 +16,9 @@ class GoldenTest
     vars = @context.as_h?
     raise "Bad context: #{@context.to_s}" if vars.nil?
 
-    ctx = Context.new(@strict ? Context::ErrorMode::Strict : Context::ErrorMode::Lax)
+    # Golden liquid run ruby tests with `render!`, that raises an exception on first error, this is the strict behavior
+    # of liquid crystal.
+    ctx = Context.new(@strict || @error ? Context::ErrorMode::Strict : Context::ErrorMode::Lax)
     vars.each do |key, value|
       ctx.set(key.as_s, yaml_any_to_liquid_any(value))
     end

--- a/spec/liquid_spec.cr
+++ b/spec/liquid_spec.cr
@@ -27,14 +27,14 @@ describe Liquid::Context do
   it "does not raise for undefined variables on strict mode" do
     ctx = Context.new(:strict)
     ctx.get("missing").raw.should eq(nil)
-    ctx.errors.map(&.message).should eq([%(Liquid error: Variable "missing" not found.)])
+    ctx.errors.map(&.message).should eq([%(Liquid error: Undefined variable: "missing".)])
     ctx.errors.map(&.class).should eq([Liquid::UndefinedVariable])
   end
 
   it "store errors for undefined variables in warn mode" do
     ctx = Context.new(:warn)
     ctx.get("missing").raw.should eq(nil)
-    ctx.errors.map(&.message).should eq([%(Liquid error: Variable "missing" not found.)])
+    ctx.errors.map(&.message).should eq([%(Liquid error: Undefined variable: "missing".)])
     ctx.errors.map(&.class).should eq([Liquid::UndefinedVariable])
   end
 end

--- a/spec/liquid_spec.cr
+++ b/spec/liquid_spec.cr
@@ -18,21 +18,23 @@ describe Liquid::Context do
     ctx["missing"]?.should be_nil
   end
 
-  it "raises on missing key in strict mode" do
-    ctx = Context.new(:strict)
-    ctx["obj"] = Any{"something" => "something"}
-    expect_raises(InvalidExpression) { ctx.get("missing") }
-    expect_raises(InvalidExpression) { ctx.get("obj.missing") }
-  end
-
-  it "returns nil for missing key on Lax mode" do
+  it "returns nil for undefined variables on Lax mode" do
     ctx = Context.new(:lax)
     ctx.get("missing").raw.should eq(nil)
+    ctx.errors.should be_empty
   end
 
-  it "returns nil for missing key on Warn mode" do
+  it "does not raise for undefined variables on strict mode" do
+    ctx = Context.new(:strict)
+    ctx.get("missing").raw.should eq(nil)
+    ctx.errors.map(&.message).should eq([%(Liquid error: Variable "missing" not found.)])
+    ctx.errors.map(&.class).should eq([Liquid::UndefinedVariable])
+  end
+
+  it "store errors for undefined variables in warn mode" do
     ctx = Context.new(:warn)
     ctx.get("missing").raw.should eq(nil)
-    ctx.errors.should eq([%(Variable "missing" not found.)])
+    ctx.errors.map(&.message).should eq([%(Liquid error: Variable "missing" not found.)])
+    ctx.errors.map(&.class).should eq([Liquid::UndefinedVariable])
   end
 end

--- a/spec/template_spec.cr
+++ b/spec/template_spec.cr
@@ -12,6 +12,7 @@ describe Template do
   it_renders("{% if 'a' != blank %}noblank{% endif %}", "noblank")
   it_renders("{% if '' > blank %}blank{% endif %}", "")
   it_renders("{% assign a = '' | split %}{% if a == blank %}blank{% endif %}", "blank")
+  it_renders("{{ a[100] }}", "", Context.new(:strict, {"a" => Any{1, 2}}))
 
   it "should render raw text" do
     tpl = Parser.parse("raw text")

--- a/src/liquid/exceptions.cr
+++ b/src/liquid/exceptions.cr
@@ -1,19 +1,43 @@
-# exceptions.cr
-
 module Liquid
+  # Base class for all exceptions raised by Liquid.cr shard.
   class LiquidException < Exception
   end
 
+  # Exception raised on syntax errors.
   class SyntaxError < LiquidException
+    # Line number where the syntax error was found.
     property line_number : Int32 = -1
-  end
-
-  class InvalidExpression < LiquidException
   end
 
   class InvalidStatement < LiquidException
   end
 
-  class FilterArgumentException < LiquidException
+  # Exception used for any non-fatal errors that can happen while rendering a liquid template.
+  class InvalidExpression < LiquidException
+    def initialize(message : String)
+      super("Liquid error: #{message}")
+    end
+  end
+
+  # Error generated when a variable used in a template doesn't exists in the current context.
+  #
+  # This exception is never raised whatever the context error mode, to access it check `Context#errors`.
+  class UndefinedVariable < InvalidExpression
+    def initialize(var_name : String)
+      super("Variable \"#{var_name}\" not found.")
+    end
+  end
+
+  # Error generated when a filter used in a template doesn't exists.
+  #
+  # This exception is only raised in `Context::ErrorMode::Strict` error mode.
+  class UndefinedFilter < InvalidExpression
+    def initialize(filter_name : String)
+      super("Undefined filter: #{filter_name}")
+    end
+  end
+
+  # Exception raised by filters if something went wrong.
+  class FilterArgumentException < InvalidExpression
   end
 end

--- a/src/liquid/exceptions.cr
+++ b/src/liquid/exceptions.cr
@@ -24,7 +24,7 @@ module Liquid
   # This exception is never raised whatever the context error mode, to access it check `Context#errors`.
   class UndefinedVariable < InvalidExpression
     def initialize(var_name : String)
-      super("Variable \"#{var_name}\" not found.")
+      super("Undefined variable: \"#{var_name}\".")
     end
   end
 

--- a/src/liquid/filters/abs.cr
+++ b/src/liquid/filters/abs.cr
@@ -16,7 +16,7 @@ module Liquid::Filters
     extend Filter
 
     def self.filter(data : Any, args : Array(Any), options : Hash(String, Any)) : Any
-      raise LiquidException.new("Unexpected argument for abs filter") if args && args.any?
+      raise FilterArgumentException.new("Unexpected argument for abs filter") if args && args.any?
 
       if data.raw.is_a? Number
         Any.new data.raw.as(Number).abs

--- a/src/liquid/filters/append.cr
+++ b/src/liquid/filters/append.cr
@@ -23,8 +23,8 @@ module Liquid::Filters
     extend Filter
 
     def self.filter(data : Any, args : Array(Any), options : Hash(String, Any)) : Any
-      raise LiquidException.new("Missing argument for append filter") if args.nil? || args.empty?
-      raise LiquidException.new("Too many arguments for append filter") if args.size > 1
+      raise FilterArgumentException.new("Missing argument for append filter") if args.nil? || args.empty?
+      raise FilterArgumentException.new("Too many arguments for append filter") if args.size > 1
 
       Any.new(data.to_s + args.first.to_s)
     end

--- a/src/liquid/filters/capitalize.cr
+++ b/src/liquid/filters/capitalize.cr
@@ -20,7 +20,7 @@ module Liquid::Filters
     extend Filter
 
     def self.filter(data : Any, args : Array(Any), options : Hash(String, Any)) : Any
-      raise LiquidException.new("Unexpected argument for capitalize filter") if args && args.any?
+      raise FilterArgumentException.new("Unexpected argument for capitalize filter") if args && args.any?
 
       raw = data.raw
       if raw.is_a?(String)

--- a/src/liquid/filters/ceil.cr
+++ b/src/liquid/filters/ceil.cr
@@ -31,7 +31,7 @@ module Liquid::Filters
     extend Filter
 
     def self.filter(data : Any, args : Array(Any), options : Hash(String, Any)) : Any
-      raise LiquidException.new("Unexpected argument for ceil filter") if args && args.any?
+      raise FilterArgumentException.new("Unexpected argument for ceil filter") if args && args.any?
 
       if (raw = data.raw) && raw.is_a? Number
         Any.new(raw.ceil.to_i)

--- a/src/liquid/filters/floor.cr
+++ b/src/liquid/filters/floor.cr
@@ -14,7 +14,7 @@ module Liquid::Filters
     extend Filter
 
     def self.filter(data : Any, args : Array(Any), options : Hash(String, Any)) : Any
-      raise LiquidException.new("Unexpected argument for floor filter") if args && args.any?
+      raise FilterArgumentException.new("Unexpected argument for floor filter") if args && args.any?
 
       if (raw = data.raw) && raw.is_a? Number
         Any.new(raw.floor.to_i)


### PR DESCRIPTION
- Silent emit nil and do not raise `IndexError` on array out of bounds errors (like shopify liquid).
- Only raise exceptions under `LiquidException` hierarchy.
- Store exceptions instead of strings on `Context#errors`, so we can later add mode info on exception objects.
- Do not raise exceptions on undefined variables, even on Strict mode (like shopify liquid).
- Render the filter error on `FilterArgumentException` instead of raising (like shopify liquid), but raises on Strict mode, unlike Shopify liquid that does it only if rendering with `render!`
- Fix some filters raising `LiquidException` instead of `FilterArgumentException`.
- Add some documentation.