### PR TITLE
Add Any#as_number_or_zero

### DIFF
--- a/spec/any_spec.cr
+++ b/spec/any_spec.cr
@@ -1,0 +1,24 @@
+require "./spec_helper"
+
+describe Liquid::Any do
+  it "determines if underlying value is a number or not" do
+    any = Any.new(5)
+    any.as_number?.should eq(5)
+
+    any = Any.new(5.0)
+    any.as_number?.should eq(5.0)
+
+    any = Any.new("5.0")
+    any.as_number?.should eq(5.0)
+
+    any = Any.new("Hello, world!")
+    any.as_number?.should be_nil
+  end
+
+  it "raises if underlying value is not a number" do
+    expect_raises(TypeCastError, "Cast from String to Number+ failed") do
+      any = Any.new("Hello, world!")
+      any.as_number
+    end
+  end
+end

--- a/spec/any_spec.cr
+++ b/spec/any_spec.cr
@@ -16,7 +16,7 @@ describe Liquid::Any do
   end
 
   it "raises if underlying value is not a number" do
-    expect_raises(TypeCastError, "Cast from String to Number+ failed") do
+    expect_raises(TypeCastError, "Cast to Number+ failed") do
       any = Any.new("Hello, world!")
       any.as_number
     end

--- a/src/liquid/any.cr
+++ b/src/liquid/any.cr
@@ -262,7 +262,7 @@ module Liquid
     # Checks that the underlying value is a `Number`, and returns its value.
     # Raises otherwise.
     def as_number : Number
-      as_number? || raise TypeCastError.new("Cast from String to Number+ failed")
+      as_number? || raise TypeCastError.new("Cast to Number+ failed")
     end
 
     # Checks that the underlying value is a `Number`, and returns its value.

--- a/src/liquid/any.cr
+++ b/src/liquid/any.cr
@@ -259,10 +259,14 @@ module Liquid
       Any.new(-raw)
     end
 
+    # Checks that the underlying value is a `Number`, and returns its value.
+    # Raises otherwise.
     def as_number : Number
-      as_number? || 0
+      as_number? || raise TypeCastError.new("Cast from String to Number+ failed")
     end
 
+    # Checks that the underlying value is a `Number`, and returns its value.
+    # Returns `nil` otherwise.
     def as_number?
       raw = @raw
       if raw.is_a?(Number)
@@ -274,6 +278,12 @@ module Liquid
       else
         nil
       end
+    end
+
+    # Checks that the underlying value is a `Number`, and returns its value.
+    # Returns 0 otherwise.
+    def as_number_or_zero : Number
+      as_number? || 0
     end
 
     def to_s(io : IO) : Nil

--- a/src/liquid/filters/at_least.cr
+++ b/src/liquid/filters/at_least.cr
@@ -14,8 +14,8 @@ module Liquid::Filters
     def self.filter(data : Any, args : Array(Any), options : Hash(String, Any)) : Any
       raise FilterArgumentException.new("at_least filter expects one argument.") if args.size != 1
 
-      min_value = args.first.as_number
-      result = data.as_number
+      min_value = args.first.as_number_or_zero
+      result = data.as_number_or_zero
       result = min_value if min_value > result
 
       Any.new(result)

--- a/src/liquid/filters/at_most.cr
+++ b/src/liquid/filters/at_most.cr
@@ -14,8 +14,8 @@ module Liquid::Filters
     def self.filter(data : Any, args : Array(Any), options : Hash(String, Any)) : Any
       raise FilterArgumentException.new("at_most filter expects one argument.") if args.size != 1
 
-      max_value = args.first.as_number
-      result = data.as_number
+      max_value = args.first.as_number_or_zero
+      result = data.as_number_or_zero
       result = max_value if result > max_value
 
       Any.new(result)

--- a/src/liquid/filters/divided_by.cr
+++ b/src/liquid/filters/divided_by.cr
@@ -7,8 +7,8 @@ module Liquid::Filters
     def self.filter(data : Any, args : Array(Any), options : Hash(String, Any)) : Any
       raise FilterArgumentException.new("divided_by filter expects one argument.") if args.size != 1
 
-      lvalue = data.as_number
-      rvalue = args.first.as_number
+      lvalue = data.as_number_or_zero
+      rvalue = args.first.as_number_or_zero
 
       raise FilterArgumentException.new("divided_by filter cannot divide by 0 or 0.0.") if rvalue.zero?
       return Any.new(lvalue // rvalue) if rvalue.is_a?(Int) && lvalue.is_a?(Int)


### PR DESCRIPTION
I found out that the 0 return for non-numbers is essential for compatibility with the Ruby Liquid library, so I created a new method with a more accurate name for that functionality.