### PR TITLE
Fix codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
+      - name: Check formatting
+        run: crystal tool format --check
       - name: Install shards
         run: shards update
       - name: Run tests
         run: crystal spec --order=random
-      - name: Check formatting
-        run: crystal tool format --check
         if: matrix.os == 'ubuntu-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *~
 \#*\#
 
+/spec/integration/codegen-test-*
+
 # Libraries don't need dependency lock
 # Dependencies will be locked in application that uses them
 /shard.lock

--- a/src/liquid/blank.cr
+++ b/src/liquid/blank.cr
@@ -17,5 +17,9 @@ module Liquid
     def ==(other : Any)
       self == other.raw
     end
+
+    def inspect(io : IO)
+      io << "Liquid::Blank.new"
+    end
   end
 end

--- a/src/liquid/blocks/block.cr
+++ b/src/liquid/blocks/block.cr
@@ -23,7 +23,7 @@ module Liquid::Block
       end
     end
 
-    protected def inspect(io : IO)
+    protected def inspect(io : IO, &)
       io << '<'
       io << '-' if lstrip?
       io << ' '

--- a/src/liquid/blocks/when.cr
+++ b/src/liquid/blocks/when.cr
@@ -2,7 +2,7 @@ require "./block"
 
 module Liquid::Block
   class When < InlineBlock
-    @when_expressions : Array(Expression)
+    getter when_expressions : Array(Expression)
 
     def initialize(content : String)
       @when_expressions = Array(Expression).new

--- a/src/liquid/context.cr
+++ b/src/liquid/context.cr
@@ -106,6 +106,17 @@ module Liquid
       @data[var] = value
     end
 
+    @[Deprecated("Use `set(String, ::Liquid::Any)`")]
+    def set(var : String, value : Hash(String, T)) : Any forall T
+      mapped_values = value.transform_values { |v| Any.new(v) }
+      set(var, mapped_values)
+    end
+
+    # Sets the value for *var* to the given *value*.
+    def set(var : String, value : Hash(String, Any)) : Any
+      set(var, Any.new(value))
+    end
+
     # Sets the value for *var* to an instance of `Liquid::Any` generated from *value*.
     def set(var : String, value : Any::Type) : Any
       set(var, Any.new(value))

--- a/src/liquid/context.cr
+++ b/src/liquid/context.cr
@@ -38,6 +38,7 @@ module Liquid
     delegate :strict?, to: @error_mode
     delegate :warn?, to: @error_mode
     delegate :lax?, to: @error_mode
+    delegate :each, to: @data
 
     @[Deprecated("Use `initialize(ErrorMode)` instead.")]
     def initialize(strict : Bool)

--- a/src/liquid/for_loop.cr
+++ b/src/liquid/for_loop.cr
@@ -10,7 +10,7 @@ module Liquid
     end
 
     @[Ignore]
-    def each
+    def each(&)
       collection = @collection
       if collection.is_a?(Array) || collection.is_a?(Range)
         collection.each do |val|

--- a/src/liquid/template.cr
+++ b/src/liquid/template.cr
@@ -49,12 +49,12 @@ module Liquid
 
       unless context
         context = "context"
-        io.puts <<-EOF
-context = Liquid::Context.new
-{% for var in @type.instance_vars %}
-    context.set {{var.id.stringify}}, @{{var.id}}
-{% end %}
-EOF
+        io.puts <<-CRYSTAL
+        context = Liquid::Context.new
+        {% for var in @type.instance_vars %}
+            context.set({{var.id.stringify}}, @{{var.id}})
+        {% end %}
+        CRYSTAL
       end
 
       root.accept visitor

--- a/src/liquid/tokenizer.cr
+++ b/src/liquid/tokenizer.cr
@@ -38,7 +38,7 @@ module Liquid
     TemplateParser        = /(#{PartialTemplateParser}|#{AnyStartingTag})/m
     VariableParser        = /\[[^\]]+\]|#{VariableSegment}+\??/
 
-    def self.parse(string : String) : Nil
+    def self.parse(string : String, &) : Nil
       line_number = 1
 
       string.split(TemplateParser) do |value|


### PR DESCRIPTION
Codegen is not tested at all, so before think about fix it is better to add tests for it.

The plan is:

- [x] Let golden test run against codegen visitor.
- [x] Compare codegen output with expected golden test output.
- [x] Fix the code gen.

I had some time today and made the tests run against the codegen, still in a "it worked" state, very draft, but I'm pushing it here because if someone with time is interested in fix this there's something to start on.

All codegen tests are tagged with `codegen`, currently if you run: `crystal spec --tag codegen --fail-fast` you will reproduce issue #87

```
$ crystal spec --tag codegen --fail-fast
In spec/integration/4wtigu49-liquid-codegen-test.cr:4:3

 4 | {{ run "../../src/process", "/home/hugo/src/pet/liquid.cr/spec/integration/x6qfc7po-test.liquid", "io", "context" }}
     ^
Error: expanding macro


In src/process.cr:7:5

 7 | tpl.to_code io, STDOUT, context
         ^------
Error: instantiating 'Liquid::Template#to_code(String, IO::FileDescriptor, (String | Nil))'


In src/liquid/template.cr:60:12

 60 | root.accept visitor
           ^-----
Error: instantiating 'Liquid::Block::Root#accept(Liquid::CodeGenVisitor)'


In src/liquid/blocks/block.cr:12:15

 12 | visitor.visit self
              ^----
Error: instantiating 'Liquid::CodeGenVisitor#visit(Liquid::Block::Root)'


In src/liquid/codegen_visitor.cr:49:28

 49 | node.children.each &.accept self
                           ^-----
Error: instantiating 'Liquid::Block::Node+#accept(Liquid::CodeGenVisitor)'


In src/liquid/blocks/block.cr:12:15

 12 | visitor.visit self
              ^----
Error: instantiating 'Liquid::CodeGenVisitor#visit(Liquid::Block::Node+)'


In src/liquid/codegen_visitor.cr:58:76

 58 | Liquid::Block::ExpressionNode.new("#{escape node.value.var}")))
                                                             ^--
Error: undefined method 'var' for Liquid::Expression
F

Failures:

  1) Golden Liquid Tests liquid.golden.abs_filter negative float (codegen)
     Failure/Error: $?.exit_code.should eq(0)

       Expected: 0
            got: 1

     # spec/integration/integration_spec.cr:43

Aborted!
Finished in 626.58 milliseconds
1 examples, 1 failures, 0 errors, 0 pending

Failed examples:

crystal spec spec/integration/integration_spec.cr:1 # Golden Liquid Tests liquid.golden.abs_filter negative float (codegen)
```